### PR TITLE
feat: 한국공학대학교 학생 이메일 인증번호 발급 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+application-sec.yaml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,16 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'software.amazon.awssdk:ses:2.31.77' // AWS 이메일 서비스
+	implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8' // 메모리 캐싱 라이브러리
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/tugether_be/auth/controller/AuthController.java
+++ b/src/main/java/com/example/tugether_be/auth/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.example.tugether_be.auth.controller;
+
+import com.example.tugether_be.auth.dto.EmailDto;
+import com.example.tugether_be.auth.service.EmailVerificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final EmailVerificationService emailVerificationService;
+
+    @PostMapping("/email/issue-code")
+    public ResponseEntity<String> issueEmailCode(@RequestBody EmailDto emailDto) {
+        emailVerificationService.sendVerificationCode(emailDto.getEmail());
+        return ResponseEntity.ok("인증 코드가 전송되었습니다.");
+    }
+}

--- a/src/main/java/com/example/tugether_be/auth/dto/EmailDto.java
+++ b/src/main/java/com/example/tugether_be/auth/dto/EmailDto.java
@@ -1,0 +1,13 @@
+package com.example.tugether_be.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailDto {
+
+    private String email;
+
+    private String code;
+}

--- a/src/main/java/com/example/tugether_be/auth/service/EmailVerificationService.java
+++ b/src/main/java/com/example/tugether_be/auth/service/EmailVerificationService.java
@@ -1,0 +1,96 @@
+package com.example.tugether_be.auth.service;
+
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.ses.model.*;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class EmailVerificationService {
+
+    private final SesClient sesClient;
+    private final Cache<String, String> emailCodeCache;
+
+    private static final String FROM_EMAIL = "kwonjh0406@gmail.com";
+    private static final String SUBJECT = "이메일 인증 코드";
+
+    public EmailVerificationService(SesClient sesClient) {
+        this.sesClient = sesClient;
+        this.emailCodeCache = Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofMinutes(10))
+                .maximumSize(10000)
+                .build();
+    }
+
+    public void sendVerificationCode(String email) {
+        validateEmailDomain(email);
+        String code = generateCode();
+
+        // 캐시에 저장 (같은 키일 경우 덮어쓰기)
+        emailCodeCache.put(email, code);
+
+        String body = String.format("[TUgether] 인증 코드는 [%s] 입니다. 10분 내에 입력해주세요.", code);
+
+        SendEmailRequest request = SendEmailRequest.builder()
+                .source(FROM_EMAIL)
+                .destination(Destination.builder()
+                        .toAddresses(email)
+                        .build())
+                .message(Message.builder()
+                        .subject(Content.builder().data(SUBJECT).charset("UTF-8").build())
+                        .body(Body.builder()
+                                .text(Content.builder().data(body).charset("UTF-8").build())
+                                .build())
+                        .build())
+                .build();
+
+        sesClient.sendEmail(request);
+        log.info("이메일 [{}] 에 인증 코드 [{}] 전송 완료", email, code);
+    }
+
+    public boolean verifyCode(String email, String inputCode) {
+        String cachedCode = emailCodeCache.getIfPresent(email);
+        if (cachedCode == null) {
+            throw new IllegalStateException("인증 코드가 만료되었거나 존재하지 않습니다.");
+        }
+        if (!cachedCode.equalsIgnoreCase(inputCode)) {
+            throw new IllegalArgumentException("인증 코드가 일치하지 않습니다.");
+        }
+
+        // 인증 성공 시 캐시에서 제거
+        emailCodeCache.invalidate(email);
+        return true;
+    }
+
+    private String generateCode() {
+        return UUID.randomUUID().toString().substring(0, 6).toUpperCase();
+    }
+
+    private void validateEmailDomain(String email) {
+        if (!email.toLowerCase().endsWith("@tukorea.ac.kr")) {
+            throw new IllegalArgumentException("tukorea.ac.kr 도메인만 허용됩니다.");
+        }
+    }
+
+    public void verifyCodeOrThrow(String email, String inputCode) {
+        String cachedCode = emailCodeCache.getIfPresent(email);
+        if (cachedCode == null) {
+            throw new IllegalStateException("인증 코드가 만료되었거나 존재하지 않습니다.");
+        }
+        if (!cachedCode.equalsIgnoreCase(inputCode)) {
+            throw new IllegalArgumentException("인증 코드가 일치하지 않습니다.");
+        }
+
+        // 성공 시 캐시에서 제거
+        emailCodeCache.invalidate(email);
+    }
+
+}
+

--- a/src/main/java/com/example/tugether_be/config/SesConfig.java
+++ b/src/main/java/com/example/tugether_be/config/SesConfig.java
@@ -1,0 +1,31 @@
+package com.example.tugether_be.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ses.SesClient;
+@Configuration
+public class SesConfig {
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public SesClient sesClient() {
+        AwsBasicCredentials awsCreds = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return SesClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+                .build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=tugether-be

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,6 @@
+spring:
+  application:
+    name: tugether-be
+
+  profiles:
+    active: sec


### PR DESCRIPTION
tukorea.ac.kr 이메일에 대해서만 가입 가능
이메일 인증번호 발급 후 TTL 메모리 캐시로 메일, 코드 쌍 관리
AWS SES 이용 이메일 전송

의존성 추가
- AWS SDK SES
- Caffeine